### PR TITLE
Support mainline kernel

### DIFF
--- a/src/drivers/ppv2/cls/pp2_flow_rules.c
+++ b/src/drivers/ppv2/cls/pp2_flow_rules.c
@@ -3377,8 +3377,10 @@ static int pp2_cls_find_flows_per_lkp(uintptr_t cpu_slot,
 		}
 
 		if (!engine) {
-			pr_err("didn't find any flows\n");
-			break;
+			if (is_last)
+				break;
+			else
+				continue;
 		}
 
 		rc = mv_pp2x_cls_sw_flow_extra_get(&fe, &lkp_type, &tmp);

--- a/src/drivers/ppv2/pp2_utils_us.c
+++ b/src/drivers/ppv2/pp2_utils_us.c
@@ -135,10 +135,14 @@ static int pp2_get_devtree_port_data(struct netdev_if_params *netdev_params)
 	for (i = 0, cp110_num = 0; i < num_inst; i++, cp110_num++) {
 		err = -1;
 		while (cp110_num < PP2_MAX_NUM_PACKPROCS) {
-			if (lnx_id == LNX_4_4_x)
-				sprintf(cp110path, pp2_frm[lnx_id].devtree_path, cp110_num);
-			else
-				sprintf(cp110path, pp2_frm[lnx_id].devtree_path, cp110_num);
+			/* HACK: compatibility with mainline kernel DT layout.
+			 * Only compatible with Armada 8k/7k.
+			 */
+			char *cp_base = cp110_num ? "f4000000" : "f2000000";
+
+			sprintf(cp110path,
+				"/proc/device-tree/cp%d/config-space@%s/ethernet@0/",
+				cp110_num, cp_base);
 			err = access(cp110path, F_OK);
 			if (!err)
 				break;

--- a/src/env/sys_iomem.c
+++ b/src/env/sys_iomem.c
@@ -115,7 +115,7 @@ struct sys_iomem_format {
 #define PP2_NETDEV_PATH		"/sys/class/net/"
 
 #define UIO_HDR_STR		"uio_%s"
-#define UIO_ID_FORMAT_STR	"_%d"
+#define UIO_ID_FORMAT_STR	"_cp%d"
 #define UIO_MAX_FORMAT_SZ	(sizeof(UIO_HDR_STR) + sizeof(UIO_ID_FORMAT_STR))
 
 


### PR DESCRIPTION
These patches allow MUSDK to build and run on top of a relatively recent kernel version 5.8 on the Armada 8K platform. Other platforms require some tweaks the second patch.

The kernel needs patching as well. Find the kernel patches at https://github.com/baruchsiach/linux/tree/armada-musdk-v5.8.