### PR TITLE
fix build with hardening

### DIFF
--- a/apps/common/mvapp.c
+++ b/apps/common/mvapp.c
@@ -237,12 +237,13 @@ static int print_to_file_cb(const char *fmt, ...)
 		printf("%s: buffer overflow (%d chars)\n", __func__, n);
 	va_end(ap);
 
-	fd = open(mvapp->cli_out_filename, O_CREAT | O_WRONLY | O_APPEND);
+	fd = open(mvapp->cli_out_filename, O_CREAT | O_WRONLY | O_APPEND, S_IWUSR | S_IROTH);
 	if (fd <= 0) {
 		pr_err("can't open CLI file (%s)\n", mvapp->cli_out_filename);
 		return -EIO;
 	}
-	write(fd, buf, n);
+	if (write(fd, buf, n) != n)
+		pr_err("can't write %d chars to CLI file (%s)\n", n, mvapp->cli_out_filename);
 	close(fd);
 	return 0;
 }

--- a/apps/examples/ppv2/pkt_gen/pkt_gen.c
+++ b/apps/examples/ppv2/pkt_gen/pkt_gen.c
@@ -1167,10 +1167,10 @@ static int extract_ip_range(struct ip_range *r, char *argv)
 	}
 	{
 		struct in_addr a;
-		char buf1[16]; /* one ip address */
+		char buf1[INET_ADDRSTRLEN + 1]; /* one ip address */
 
 		a.s_addr = htonl(r->end);
-		strncpy(buf1, inet_ntoa(a), sizeof(buf1));
+		strncpy(buf1, inet_ntoa(a), sizeof(buf1) - 1);
 		a.s_addr = htonl(r->start);
 		pr_debug("range is %s:%d to %s:%d\n", inet_ntoa(a), r->port0, buf1, r->port1);
 	}

--- a/apps/tests/dmax2/pkt_gen/pkt_gen.c
+++ b/apps/tests/dmax2/pkt_gen/pkt_gen.c
@@ -990,10 +990,10 @@ static int extract_ip_range(struct ip_range *r, char *argv)
 	}
 	{
 		struct in_addr a;
-		char buf1[16]; /* one ip address */
+		char buf1[INET_ADDRSTRLEN+1]; /* one ip address */
 
 		a.s_addr = htonl(r->end);
-		strncpy(buf1, inet_ntoa(a), sizeof(buf1));
+		strncpy(buf1, inet_ntoa(a), sizeof(buf1) - 1);
 		a.s_addr = htonl(r->start);
 		pr_debug("range is %s:%d to %s:%d\n", inet_ntoa(a), r->port0, buf1, r->port1);
 	}

--- a/src/drivers/ppv2/pp2_utils_us.c
+++ b/src/drivers/ppv2/pp2_utils_us.c
@@ -168,8 +168,13 @@ static int pp2_get_devtree_port_data(struct netdev_if_params *netdev_params)
 			netdev_params[idx].ppio_id = j;
 			netdev_params[idx].pp_id = i;
 
-			fgets(buf, sizeof(buf), fp);
+			if (fgets(buf, sizeof(buf), fp) != buf)
+				err = -EIO;
 			fclose(fp);
+			if (err) {
+				pr_err("error reading file %s\n", fullpath);
+				return err;
+			}
 
 			if (strcmp("disabled", buf) == 0) {
 				pr_debug("port %d:%d is disabled\n", i, j);

--- a/src/env/of.c
+++ b/src/env/of.c
@@ -134,7 +134,10 @@ static int create_of_sh(void)
 	fputs(script_str, of_sh);
 	fclose(of_sh);
 	snprintf(command, sizeof(command), "sync; chmod 755 %s", OF_SH_FILENAME);
-	system(command);
+	if (system(command) < 0) {
+		pr_err("couldn't execute command (%s)\n", command);
+		return -errno;
+	}
 	return 0;
 }
 

--- a/src/include/lib/lib_misc.h
+++ b/src/include/lib/lib_misc.h
@@ -136,7 +136,7 @@ do {										\
 	}									\
 	str_len = snprintf(&tmp_buf[tab_len], size - pos, __VA_ARGS__);		\
 	if ((str_len + tab_len) <= (size - pos))				\
-		strncpy(&buff[pos], &tmp_buf[0], (size_t)(str_len + tab_len));	\
+		strcpy(&buff[pos], &tmp_buf[0]);				\
 	else									\
 		pr_warn("skip write (%s): buf too short (%d)!\n",		\
 			tmp_buf, size);						\

--- a/src/lib/file_utils.c
+++ b/src/lib/file_utils.c
@@ -103,10 +103,11 @@
  ***********************/
 int write_buf_to_file(char *file_name, char *buff, u32 size)
 {
+	const mode_t mode = S_IWUSR | S_IROTH;
 	size_t	s;
 	int	fd;
 
-	fd = open(file_name, O_RDWR | O_CREAT);
+	fd = open(file_name, O_RDWR | O_CREAT, mode);
 	if (fd == -1) {
 		pr_err("Failed to open file %s\n", file_name);
 		return -EIO;
@@ -126,7 +127,7 @@ int write_buf_to_file(char *file_name, char *buff, u32 size)
 
 	sync();
 
-	chmod(file_name, S_IWUSR | S_IROTH);
+	chmod(file_name, mode);
 
 	return 0;
 }
@@ -153,4 +154,3 @@ int read_file_to_buf(char *file_name, char *buff, u32 size)
 	close(fd);
 	return 0;
 }
-


### PR DESCRIPTION
Fix GCC 10 warnings with -D_FORTIFY_SOURCE=2 and -Werror.

-Wstringop-overflow witn inet_aton(): true positive.
    Give strncpy() space to put the terminating '\0'.

-Wstringop-overflow with json_print_to_buffer(): false positive.
    Use strcpy() instead of strncpy() giving the warning,
    because the size of the buffer is checked explicitly.

-Wunused-result with system(), fgets(), write(): true positive.
    Check the result and print an error. No control flow change.

Signed-off-by: Dmitry Kozlyuk <dmitry.kozliuk@gmail.com>